### PR TITLE
Add responsive styles support

### DIFF
--- a/src/babel-plugin/index.ts
+++ b/src/babel-plugin/index.ts
@@ -5,6 +5,10 @@ import { sheet } from "../sheet";
 import { writeCSSFile } from "./writeCSSfile";
 import path from "path";
 
+export type BabelPluginOption = {
+  breakpoints?: Record<string, string>; // {sm: '400px', md: '700px'}
+};
+
 const plugin = (core: Core): PluginObj => {
   return {
     name: "zero-styled-plugin",

--- a/src/babel-plugin/transform.ts
+++ b/src/babel-plugin/transform.ts
@@ -1,20 +1,7 @@
-import * as parser from "@babel/parser";
-import traverse from "@babel/traverse";
-import generate from "@babel/generator";
-import {sheet} from "../sheet";
-import {extractStylePropsFromAST} from "./extractStyleFromAST";
-import {combinedStyles} from "../system";
-import {visitor} from "./visitor";
-import {
-  template,
-  types as t,
-  parseSync,
-  transformFromAstSync,
-  transformSync,
-  transformAsync,
-} from "@babel/core";
-import type {ParseResult} from "@babel/core";
+import { types as t, parseSync, transformFromAstSync } from "@babel/core";
+import type { ParseResult } from "@babel/core";
 import zeroStyledPlugin from "./index";
+import { BabelPluginOption } from "./index";
 
 export async function transform(code: string, id: string) {
   const file: ParseResult | null = parseSync(code);

--- a/src/sheet/index.ts
+++ b/src/sheet/index.ts
@@ -6,9 +6,14 @@ export interface Rule {
 }
 
 export class Sheet {
+  private static instance: Sheet;
   private rules: Rule[];
   constructor() {
     this.rules = [];
+    if (Sheet.instance) {
+      throw new Error("You can only create one instance!");
+    }
+    Sheet.instance = this;
   }
 
   addRule(css: string): string {
@@ -33,6 +38,10 @@ export class Sheet {
   getCSS(): string {
     this.removeDuplicates();
     return this.rules.map((rule) => `.${rule.id} {${rule.css}}`).join("\n");
+  }
+
+  reset() {
+    this.rules = [];
   }
 }
 

--- a/src/sheet/sheet.test.ts
+++ b/src/sheet/sheet.test.ts
@@ -1,10 +1,9 @@
-import { Sheet } from ".";
+import { Sheet, sheet } from ".";
 import { describe, expect, test, beforeEach } from "@jest/globals";
 
 describe("Sheet class", () => {
-  let sheet: Sheet;
   beforeEach(() => {
-    sheet = new Sheet();
+    sheet.reset();
   });
 
   test("addRule() should add a new rule with a generated ID", () => {

--- a/src/system/compose.test.ts
+++ b/src/system/compose.test.ts
@@ -15,7 +15,7 @@ describe("compose function", () => {
       width: "100%",
       bg: "red",
       color: "red",
-      flexDir: "column",
+      flexDir: ["column", "row"],
     };
     // Act
     const styles = combinedFunction(props);

--- a/src/system/compose.ts
+++ b/src/system/compose.ts
@@ -10,7 +10,7 @@ export type StyledProps = SpaceProps &
   ColorProps &
   FlexProps;
 
-type StyleFunction = (props: StyledProps) => string;
+export type StyleFunction = (props: StyledProps) => string;
 
 /**
  * Composes multiple style functions into a single style function.

--- a/src/system/flex.ts
+++ b/src/system/flex.ts
@@ -1,7 +1,8 @@
 import { toCssUnit } from "./toCSS";
 import { FlexKeys } from "./keys";
+import { applyResponsiveStyles } from "./responsive";
 
-export type FlexProps = Partial<Record<FlexKeys, string>>;
+export type FlexProps = Partial<Record<FlexKeys, string | string[]>>;
 
 const flexMappings: Record<FlexKeys, string> = {
   flexDir: "flex-direction",
@@ -21,7 +22,8 @@ export const flex = (props: FlexProps): string => {
     const cssValue = props[key as FlexKeys];
     if (cssValue) {
       const cssProperty = flexMappings[key as FlexKeys];
-      styles += `${cssProperty}: ${cssValue}; `;
+      // styles += `${cssProperty}: ${cssValue}; `;
+      styles += applyResponsiveStyles(cssProperty, cssValue);
     }
   }
 

--- a/src/system/responsive.test.ts
+++ b/src/system/responsive.test.ts
@@ -1,0 +1,29 @@
+import { applyResponsiveStyles } from "./responsive";
+import { describe, expect, test, beforeEach } from "@jest/globals";
+
+describe("applyResponsiveStyles", () => {
+  test("returns a single CSS rule when given a single value", () => {
+    // Arrange
+    const cssProperty = "margin-top";
+    const cssValue = "10px";
+    const expected = "margin-top: 10px; ";
+
+    // Act
+    const result = applyResponsiveStyles(cssProperty, cssValue);
+
+    // Assert
+    expect(result).toBe(expected);
+  });
+
+  test("returns a base CSS rule and media queries when given an array of values", () => {
+    // Arrange
+    const cssProperty = "margin-top";
+    const cssValues = ["10px", "20px", "30px"];
+
+    // Act
+    const result = applyResponsiveStyles(cssProperty, cssValues);
+
+    // Assert
+    expect(result).toContain("@media");
+  });
+});

--- a/src/system/responsive.ts
+++ b/src/system/responsive.ts
@@ -1,0 +1,22 @@
+import { StyledProps, StyleFunction } from "./compose";
+import { theme } from "../theme";
+
+export const applyResponsiveStyles = (
+  cssProperty: string,
+  cssValues: string | string[]
+): string => {
+  const breakpoints = theme.getBreakpoints();
+  if (Array.isArray(cssValues)) {
+    const baseValue = cssValues[0];
+    const mediaQueries = cssValues.slice(1).map((value, index) => {
+      const breakpoint = Object.keys(breakpoints)[index];
+      return `@media (min-width: ${breakpoints[breakpoint]}) {
+            ${cssProperty}: ${value};
+          }`;
+    });
+
+    return `${cssProperty}: ${baseValue}; ${mediaQueries.join(" ")}`;
+  }
+
+  return `${cssProperty}: ${cssValues}; `;
+};

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,0 +1,33 @@
+export const defaultBreakpoints = Object.freeze({
+  sm: "576px",
+  md: "768px",
+  lg: "992px",
+  xl: "1200px",
+});
+
+export class Theme {
+  private static instance: Theme;
+  private _breakpoints: Record<string, string>;
+
+  constructor() {
+    this._breakpoints = defaultBreakpoints;
+    if (Theme.instance) {
+      throw new Error("You can only create one instance!");
+    }
+    Theme.instance = this;
+  }
+
+  setBreakpoints(breakpoints: Record<string, string>) {
+    this._breakpoints = breakpoints;
+  }
+
+  getBreakpoints(): Record<string, string> {
+    return this._breakpoints;
+  }
+
+  reset() {
+    this._breakpoints = defaultBreakpoints;
+  }
+}
+
+export const theme = new Theme();

--- a/src/theme/theme.test.ts
+++ b/src/theme/theme.test.ts
@@ -1,0 +1,36 @@
+import { Theme, theme, defaultBreakpoints } from ".";
+import { describe, expect, test, beforeEach } from "@jest/globals";
+
+describe("Theme", () => {
+  beforeEach(() => {
+    theme.reset();
+  });
+
+  test("should only allow a single instance of the Theme class", () => {
+    // Act & Assert
+    expect(() => {
+      new Theme(); // This should throw an error
+    }).toThrowError("You can only create one instance!");
+  });
+
+  test("should allow setting and getting breakpoints", () => {
+    // Arrange
+    const breakpoints = {
+      sm: "640px",
+      md: "768px",
+      lg: "1024px",
+      xl: "1280px",
+    };
+
+    // Act
+    theme.setBreakpoints(breakpoints);
+
+    // Assert
+    expect(theme.getBreakpoints()).toEqual(breakpoints);
+  });
+
+  test("should return default breakpoints when none are set", () => {
+    // Act & Assert
+    expect(theme.getBreakpoints()).toEqual(defaultBreakpoints);
+  });
+});

--- a/src/vite/index.ts
+++ b/src/vite/index.ts
@@ -1,14 +1,20 @@
 import babel from "@babel/core";
 import zeroStyledPlugin from "../babel-plugin";
-import {
-  transform,
-  transform as zeroStyledTransform,
-} from "../babel-plugin/transform";
+import { transform } from "../babel-plugin/transform";
 import { Plugin } from "vite";
 import { sheet } from "../sheet";
 import path from "path";
+import { theme } from "../theme";
 
-export default function zeroStyled(): Plugin {
+export type VitePluginOption = {
+  breakpoints?: Record<string, string>; // {sm: '400px', md: '700px'}
+};
+
+export default function zeroStyled(options?: VitePluginOption): Plugin {
+  if (options?.breakpoints && Object.keys(options.breakpoints).length > 0) {
+    theme.setBreakpoints(options.breakpoints);
+  }
+
   return {
     name: "zero-styled",
     enforce: "post",


### PR DESCRIPTION
## Description:

This pull request adds responsive styles support to the zero-styled library. It implements the following changes:

1. Introduce a Theme class with a singleton pattern, which stores the global breakpoints for the library.
2. Update the Vite plugin to set breakpoints from user configuration, if provided.
3. Implement the applyResponsiveStyles function that takes a CSS property and an array of values or a single value, and returns a string containing the appropriate CSS rules with media queries.
4. Modify the utility functions (e.g., flex) to use the applyResponsiveStyles function to enable responsive styles support.
5. Add test cases for the applyResponsiveStyles function and the updated utility functions.
6. With these changes, users can now define responsive styles using both array and object syntax, like <Box mt={['10px', '20px']} p={4} /> and <Box mt={{ base: '10px', md: '20px' }} p={4} />.
