### PR TITLE
Implement 'z' API for zero-runtime styled components with utility props

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,15 @@ Zero-Styled is a utility-first, zero-runtime CSS-in-JS library that offers an ou
 
 
 ```tsx
-import { styled } from "zero-styled/styled";
-import { TypographyProps, ColorProps } from "zero-styled/system";
+import { styled, z } from "zero-styled";
 
 const color = 'orange'
 function App() {
   return (
     <VStack p={[4, 8]} m="2px" _hover={{ flexDir: "row" }}>
-      <Text fontSize="40px" color={color}>
+      <z.div fontSize="40px" color={color}>
         hello world
-      </Text>
+      </z.div>
     </VStack>
   );
 }
@@ -23,11 +22,7 @@ export const VStack = styled("div")`
   flex-direction: column;
 `;
 
-// You can also explicitly specify the StyledProps generic type like this:
-const Text = styled("p")<TypographyProps & ColorProps>``;
-
 export default App;
-
 ```
 
 # Features

--- a/package.json
+++ b/package.json
@@ -30,19 +30,9 @@
   ],
   "exports": {
     ".": {
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js",
-      "types": "./dist/index.d.ts"
-    },
-    "./styled": {
-      "import": "./dist/styled/index.mjs",
-      "require": "./dist/styled/index.js",
-      "types": "./dist/styled/index.d.ts"
-    },
-    "./system": {
-      "import": "./dist/system/index.mjs",
-      "require": "./dist/system/index.js",
-      "types": "./dist/system/index.d.ts"
+      "import": "./dist/core/index.mjs",
+      "require": "./dist/core/index.js",
+      "types": "./dist/core/index.d.ts"
     },
     "./vite": {
       "import": "./dist/vite/index.mjs",
@@ -52,12 +42,6 @@
   },
   "typesVersions": {
     "*": {
-      "styled": [
-        "dist/styled/index.d.ts"
-      ],
-      "system": [
-        "dist/system/index.d.ts"
-      ],
       "vite": [
         "dist/vite/index.d.ts"
       ]

--- a/playground/react-vite/src/App.tsx
+++ b/playground/react-vite/src/App.tsx
@@ -1,5 +1,4 @@
-import { styled } from "zero-styled/styled";
-import { TypographyProps, ColorProps, StyledProps } from "zero-styled/system";
+import { styled, z } from "zero-styled";
 import { Box } from "./Box";
 
 const color = "orange";
@@ -30,12 +29,12 @@ function App() {
       <Text fontSize="24px" color={colors.main.test.target}>
         Nested Member Expression
       </Text>
-      <Box color="red">hello</Box>
+      <z.div fontSize={50}>hello</z.div>
     </VStack>
   );
 }
 
-export const VStack = styled("div")<StyledProps>`
+export const VStack = styled("div")`
   display: flex;
   flex-direction: column;
   :hover {
@@ -43,6 +42,6 @@ export const VStack = styled("div")<StyledProps>`
   }
 `;
 
-const Text = styled("p")<ColorProps & TypographyProps>``;
+const Text = styled("p")``;
 
 export default App;

--- a/playground/react-vite/src/App.tsx
+++ b/playground/react-vite/src/App.tsx
@@ -16,7 +16,7 @@ function App() {
     <VStack
       p={[4, 8]}
       m={2}
-      _hover={{ flexDir: "row" }}
+      // _hover={{ flexDir: "row" }}
       display="grid"
       gridGap={1}
     >
@@ -30,6 +30,7 @@ function App() {
         Nested Member Expression
       </Text>
       <z.div fontSize={50}>hello</z.div>
+      <z.a>hello</z.a>
     </VStack>
   );
 }

--- a/playground/react-vite/src/Box.ts
+++ b/playground/react-vite/src/Box.ts
@@ -1,3 +1,3 @@
-import { styled as s } from "zero-styled/styled";
+import { styled as s } from "zero-styled";
 
 export const Box = s("div")``;

--- a/src/babel-plugin/collectImportedStyled.ts
+++ b/src/babel-plugin/collectImportedStyled.ts
@@ -14,7 +14,7 @@ export function collectImportedStyled(
   for (const importDeclaration of importDeclarations) {
     if (
       t.isImportDeclaration(importDeclaration.node) &&
-      importDeclaration.node.source.value === "zero-styled/styled"
+      importDeclaration.node.source.value === "zero-styled"
     ) {
       for (const specifier of importDeclaration.node.specifiers) {
         if (

--- a/src/babel-plugin/processZ.ts
+++ b/src/babel-plugin/processZ.ts
@@ -1,0 +1,38 @@
+import { NodePath, Node, types, template } from "@babel/core";
+import { createStyledComponent, isHTMLElement } from "../core/z";
+import { Program } from "@babel/types";
+
+export const processZ = (
+  node: NodePath<Program>,
+  t: typeof types,
+  importedStyleFunctions: Record<string, string>
+) => {
+  node.traverse({
+    CallExpression(path) {
+      const { node } = path;
+
+      if (
+        node.callee.type === "MemberExpression" &&
+        t.isIdentifier(node.callee.object) &&
+        node.callee.object.name === "React" &&
+        node.callee.property.type === "Identifier" &&
+        (node.callee.property.name === "createElement" ||
+          node.callee.property.name === "cloneElement")
+      ) {
+        const firstArg = path.get("arguments")[0];
+
+        if (
+          t.isMemberExpression(firstArg.node) &&
+          t.isIdentifier(firstArg.node.object) &&
+          firstArg.node.object.name === "z"
+        ) {
+          let htmlTag = t.isIdentifier(firstArg.node.property)
+            ? firstArg.node.property.name
+            : undefined;
+          htmlTag = isHTMLElement(htmlTag) ? htmlTag : "div";
+          firstArg.replaceWith(t.stringLiteral(htmlTag));
+        }
+      }
+    },
+  });
+};

--- a/src/babel-plugin/processZ.ts
+++ b/src/babel-plugin/processZ.ts
@@ -1,5 +1,5 @@
 import { NodePath, Node, types, template } from "@babel/core";
-import { createStyledComponent, isHTMLElement } from "../core/z";
+import { isHTMLElement } from "../core/z";
 import { Program } from "@babel/types";
 
 export const processZ = (

--- a/src/babel-plugin/visitor.ts
+++ b/src/babel-plugin/visitor.ts
@@ -11,11 +11,12 @@ import { processHTMLTag } from "./processHTMLTag";
 import { generateHash } from "../utils/hash";
 import { Node } from "@babel/core";
 import { collectImportedStyled } from "./collectImportedStyled";
+import { processZ } from "./processZ";
 
 export const styledFunctionsMap = new Map<string, Node[]>();
 
 export const visitor = ({ types: t, template }: Core) => {
-  // Keep track of the local name for the imported 'styled' function from 'zero-styled/styled'
+  // Keep track of the local name for the imported 'styled' function from 'zero-styled'
   // This is necessary to handle cases where the 'styled' function is imported with a different name
   let importedStyleFunctions: Record<string, string> = {};
 
@@ -91,6 +92,7 @@ export const visitor = ({ types: t, template }: Core) => {
         ensureReactImport(path, t);
         // Reset the importedStyleFunctions
         importedStyleFunctions = collectImportedStyled(path, t);
+        processZ(path, t, importedStyleFunctions);
       },
     },
   };

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,0 +1,2 @@
+export { styled } from "./styled";
+export { z } from "./z";

--- a/src/core/styled.ts
+++ b/src/core/styled.ts
@@ -1,0 +1,50 @@
+import React, {
+  ComponentType,
+  ReactElement,
+  ComponentProps,
+  forwardRef,
+  FunctionComponent,
+  HTMLAttributes,
+  cloneElement,
+  createElement,
+} from "react";
+import { dataAttributeName } from "../utils/assignDataAttribute";
+import {
+  ResponsiveStyle,
+  StyledProps,
+  StyledKeyType,
+  PseudoProps,
+} from "../system";
+import { sheet } from "../sheet";
+
+type StyledComponentProps<T> = T extends keyof JSX.IntrinsicElements
+  ? JSX.IntrinsicElements[T]
+  : T extends ComponentType<infer P>
+  ? P
+  : never;
+/**
+ * A higher-order component that wraps a given component with styled-system
+ * functionality and applies the data-zero-styled attribute.
+ *
+ * the Babel plugin replaces the styled function with the hashed class name during the build process.
+ * This is essentially a placeholder for the actual implementation that happens in the Babel plugin.
+ *
+ * @param Component - The component to be wrapped with styled-system functionality
+ * @returns A new component with styled-system functionality and a unique data-zero-styled attribute
+ */
+function styled<T extends keyof JSX.IntrinsicElements | ComponentType<any>>(
+  Component: T
+) {
+  const fn = function <P = StyledProps>(
+    strings: TemplateStringsArray,
+    ...interpolations: ((props: P) => ResponsiveStyle)[]
+  ): React.FC<
+    Omit<StyledComponentProps<T>, StyledKeyType> & P & Partial<PseudoProps>
+  > {
+    throw Error('Using the "styled" tag in runtime is not supported.');
+  };
+  fn.__zeroStyled = true;
+  return fn;
+}
+
+export { styled };

--- a/src/core/styled.ts
+++ b/src/core/styled.ts
@@ -17,7 +17,7 @@ import {
 } from "../system";
 import { sheet } from "../sheet";
 
-type StyledComponentProps<T> = T extends keyof JSX.IntrinsicElements
+export type StyledComponentProps<T> = T extends keyof JSX.IntrinsicElements
   ? JSX.IntrinsicElements[T]
   : T extends ComponentType<infer P>
   ? P

--- a/src/core/z.ts
+++ b/src/core/z.ts
@@ -1,0 +1,38 @@
+import { styled } from "./styled";
+import { StyledProps } from "../system";
+
+const htmlTags: Array<Partial<keyof JSX.IntrinsicElements>> = [
+  "div",
+  "a",
+  "p",
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "header",
+  "main",
+  "footer",
+  "section",
+  "input",
+  "button",
+  "ul",
+  "ol",
+  "li",
+  "img",
+  "span",
+];
+
+const createStyledComponent = (tag: keyof JSX.IntrinsicElements) => {
+  return styled(tag)<StyledProps>``;
+};
+
+const z: {
+  [K in (typeof htmlTags)[number]]: ReturnType<typeof createStyledComponent>;
+} = {} as any;
+
+for (const tag of htmlTags) {
+  z[tag] = createStyledComponent(tag);
+}
+
+export { z, createStyledComponent };

--- a/src/core/z.ts
+++ b/src/core/z.ts
@@ -1,5 +1,6 @@
-import { styled } from "./styled";
-import { StyledProps } from "../system";
+import { StyledComponentProps } from "./styled";
+import React, { ComponentProps } from "react";
+import { StyledProps, StyledKeyType, PseudoProps } from "../system";
 
 const htmlTags: Array<Partial<keyof JSX.IntrinsicElements>> = [
   "div",
@@ -23,16 +24,31 @@ const htmlTags: Array<Partial<keyof JSX.IntrinsicElements>> = [
   "span",
 ];
 
-const createStyledComponent = (tag: keyof JSX.IntrinsicElements) => {
-  return styled(tag)<StyledProps>``;
+type StyledComponent = React.FC<
+  Omit<StyledComponentProps<"div">, StyledKeyType> &
+    StyledProps &
+    Partial<PseudoProps>
+>;
+
+const createStyledComponent = <T = "div">(
+  tag: keyof JSX.IntrinsicElements
+): StyledComponent => {
+  return {} as any;
 };
 
 const z: {
-  [K in (typeof htmlTags)[number]]: ReturnType<typeof createStyledComponent>;
+  [K in (typeof htmlTags)[number]]: StyledComponent;
 } = {} as any;
 
 for (const tag of htmlTags) {
   z[tag] = createStyledComponent(tag);
 }
+
+export const isHTMLElement = (
+  _tag: unknown
+): _tag is keyof JSX.IntrinsicElements => {
+  const tag = _tag as keyof JSX.IntrinsicElements;
+  return htmlTags.includes(tag);
+};
 
 export { z, createStyledComponent };

--- a/src/core/z.ts
+++ b/src/core/z.ts
@@ -30,19 +30,9 @@ type StyledComponent = React.FC<
     Partial<PseudoProps>
 >;
 
-const createStyledComponent = <T = "div">(
-  tag: keyof JSX.IntrinsicElements
-): StyledComponent => {
-  return {} as any;
-};
-
 const z: {
   [K in (typeof htmlTags)[number]]: StyledComponent;
 } = {} as any;
-
-for (const tag of htmlTags) {
-  z[tag] = createStyledComponent(tag);
-}
 
 export const isHTMLElement = (
   _tag: unknown
@@ -51,4 +41,4 @@ export const isHTMLElement = (
   return htmlTags.includes(tag);
 };
 
-export { z, createStyledComponent };
+export { z };


### PR DESCRIPTION
This PR implements the new 'z' API for creating zero-runtime styled components with utility props, as discussed in issue #14. This makes it easier and less verbose to create components with utility props without needing to create a separate styled component using the styled function.